### PR TITLE
Modify `server.log()` behavior to include tags as separate field

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,13 +56,9 @@ function register(server, options, next) {
 		const tags = event.tags;
 		const data = event.data;
 
-		for (var i = 0; i < tags.length; i++) {
-			if (bunyanLevels.indexOf(tags[i]) !== -1) {
-				curLogger[tags[i]](tags, data);
-			}
-		}
-
-		curLogger.info(tags, data);
+		// Check if tags contain a valid log level, first match wins (default: 'info')
+		const level = tags.filter(tag => bunyanLevels.indexOf(tag) !== -1)[0] || 'info';
+		curLogger[level]({tags}, data);
 	}
 
 	return next();

--- a/test.js
+++ b/test.js
@@ -140,9 +140,9 @@ describe('Logging through server.log()', () => {
 
 					const msg = catcher.pop();
 					expect(msg).to.be.not.undefined;
-					expect(msg).to.have.all.keys(['name', 'hostname', 'pid', 'level', 'msg', 'time', 'v']);
+					expect(msg).to.have.all.keys(['name', 'hostname', 'pid', 'level', 'msg', 'tags', 'time', 'v']);
 					expect(msg.msg).to.be.contain(rndMessage);
-					expect(msg.msg).to.be.contain(level);
+					expect(msg.tags).to.be.contain(level);
 				});
 			});
 		}
@@ -170,9 +170,9 @@ describe('Logging through server.log()', () => {
 
 				const msg = catcher.pop();
 				expect(msg).to.be.not.undefined;
-				expect(msg).to.have.all.keys(['name', 'hostname', 'pid', 'level', 'msg', 'time', 'v']);
+				expect(msg).to.have.all.keys(['name', 'hostname', 'pid', 'level', 'msg', 'tags', 'time', 'v']);
 				expect(msg.msg).to.be.contain(rndMessage);
-				expect(msg.msg).to.be.contain('some_strange_level');
+				expect(msg.tags).to.be.contain('some_strange_level');
 			});
 		});
 	});


### PR DESCRIPTION
Simply stringifying tags into the message makes it hard to filter log messages
by tag during log postprocessing (e.g. Logstash). This change extracts the first
tag matching a valid log level (default value is 'info'), and adds 'tags' as
additional field.